### PR TITLE
Add PythonOperator example DAG

### DIFF
--- a/PythonOperatorExample/README.md
+++ b/PythonOperatorExample/README.md
@@ -1,0 +1,14 @@
+# PythonOperator Example
+
+This directory contains an example DAG that demonstrates the usage of the `PythonOperator` in Apache Airflow.
+
+## DAG: `python_operator_example`
+
+The DAG `python_operator_example` (defined in `dag.py`) shows how to use the `PythonOperator` to execute a simple Python function. In this case, the function prints the execution date (available as a keyword argument `ds` provided by Airflow to the callable).
+
+### How to Use
+
+1.  Ensure your Airflow environment is correctly set up.
+2.  Place the `dag.py` file in your Airflow DAGs folder.
+3.  The DAG `python_operator_example` should appear in your Airflow UI.
+4.  You can trigger it manually to see the `PythonOperator` in action. The task `print_the_context` will execute the Python function, which will print the execution date to its logs.

--- a/PythonOperatorExample/dag.py
+++ b/PythonOperatorExample/dag.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pendulum
+
+from airflow.models.dag import DAG
+from airflow.operators.python import PythonOperator
+
+def print_execution_date(**kwargs):
+    print(kwargs["ds"])
+
+with DAG(
+    dag_id="python_operator_example",
+    start_date=pendulum.datetime(2023, 10, 26, tz="UTC"),
+    catchup=False,
+    schedule=None,
+    tags=["example"],
+) as dag:
+    run_this = PythonOperator(
+        task_id="print_the_context",
+        python_callable=print_execution_date,
+    )


### PR DESCRIPTION
This commit introduces a new example demonstrating the use of the PythonOperator.

The sample includes:
- A DAG file (`PythonOperatorExample/dag.py`) with a simple PythonOperator task that prints the execution date.
- A README file (`PythonOperatorExample/README.md`) explaining the example and its usage.